### PR TITLE
had a bug within the manifest.js, that the modal.js is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,10 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
 # Ignore .env file containing credentials.
 .env*
 
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
-.env*
-.env*

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,4 +4,3 @@
 //= link_tree ../../../vendor/javascript .js
 //= link popper.js
 //= link bootstrap.min.js
-//= link modal.js


### PR DESCRIPTION
deleted the import of modal.js in the manifest.js file, as modal structure is part of the bootstrap.min.js 

reason: got a crash because modal.js doesn't exist